### PR TITLE
Added a function - Remove-CWCHostFromSession

### DIFF
--- a/ConnectWiseControlAPI/ConnectWiseControlAPI.psd1
+++ b/ConnectWiseControlAPI/ConnectWiseControlAPI.psd1
@@ -69,7 +69,7 @@
     # NestedModules = @()
 
     # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
-    FunctionsToExport = @('Get-CWCAuditInfo','Get-CWCAuditLog','Connect-CWC','Get-CWCLauncURL','Add-CWCRemoteWorkforceRequiredRole','New-CWCRemoteWorkforceAssignment','New-CWCMFA','Get-CWCLastContact','Get-CWCSession','Get-CWCSessionDetail','Invoke-CWCCommand','Invoke-CWCWake','New-CWCAccessToken','Remove-CWCSession','Update-CWCCustomProperty','Update-CWCSessionName','Get-CWCSecurityConfigurationInfo','New-CWCUser','Remove-CWCUser','Update-CWCUser','Get-CWCSessionGroup')
+    FunctionsToExport = @('Get-CWCAuditInfo','Get-CWCAuditLog','Connect-CWC','Get-CWCLauncURL','Add-CWCRemoteWorkforceRequiredRole','New-CWCRemoteWorkforceAssignment','New-CWCMFA','Get-CWCLastContact','Get-CWCSession','Get-CWCSessionDetail','Invoke-CWCCommand','Invoke-CWCWake','New-CWCAccessToken','Remove-CWCSession','Remove-CWCHostFromSession','Update-CWCCustomProperty','Update-CWCSessionName','Get-CWCSecurityConfigurationInfo','New-CWCUser','Remove-CWCUser','Update-CWCUser','Get-CWCSessionGroup')
 
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
     CmdletsToExport   = @()

--- a/ConnectWiseControlAPI/Public/PageService/Remove-CWCHostFromSession.ps1
+++ b/ConnectWiseControlAPI/Public/PageService/Remove-CWCHostFromSession.ps1
@@ -1,0 +1,38 @@
+function Remove-CWCHostFromSession
+{
+  [CmdletBinding(SupportsShouldProcess)]
+  param (
+    [Parameter(Mandatory = $True)]
+    [guid[]]$SessionID,
+    [Parameter(Mandatory = $True)]
+    [guid[]]$ConnectionID,
+    [Parameter(Mandatory = $True)]
+    [string]$Group
+  )
+
+  $Endpoint = 'Services/PageService.ashx/AddSessionEvents'
+
+  $SessionEventType = 48
+  $Body = ConvertTo-Json @(
+    @(
+      $Group
+    ),
+    @(
+      @{
+        SessionID = $SessionID
+        EventType = $SessionEventType
+        ConnectionID = $ConnectionID
+      }
+    )
+  )
+
+  $WebRequestArguments = @{
+    Endpoint = $Endpoint
+    Body     = $Body
+    Method   = 'Post'
+  }
+  if ($PSCmdlet.ShouldProcess($WebRequestArguments.Body, 'Remove-CWCHostFromSession'))
+  {
+    Invoke-CWCWebRequest -Arguments $WebRequestArguments
+  }
+}


### PR DESCRIPTION
The equivalent of [x] for a connected host.  In my use case this is so that I can use the module to see which users have more than one concurrent access session and kick any users that shouldn't be using more than one licence.