### PR TITLE
Update Remove-CWCSession.ps1 to Correct JSON Format with multiple GUIDs

### DIFF
--- a/ConnectWiseControlAPI/Public/PageService/Remove-CWCSession.ps1
+++ b/ConnectWiseControlAPI/Public/PageService/Remove-CWCSession.ps1
@@ -12,15 +12,21 @@ function Remove-CWCSession
 
   $SessionEventType = 21
   $Body = ConvertTo-Json @(
+
+  $GuidList = @()
+  foreach ($SessionID in $GUID)
+  {
+    $GuidList += @{
+      SessionID = $SessionID
+      EventType = $SessionEventType
+    }
+  }
+
+  $Body = ConvertTo-Json -Compress -InputObject @(
     @(
       $Group
     ),
-    @(
-      @{
-        SessionID = $GUID
-        EventType = $SessionEventType
-      }
-    )
+    $GuidList
   )
 
   $WebRequestArguments = @{

--- a/ConnectWiseControlAPI/Public/PageService/Remove-CWCSession.ps1
+++ b/ConnectWiseControlAPI/Public/PageService/Remove-CWCSession.ps1
@@ -11,7 +11,6 @@ function Remove-CWCSession
   $Endpoint = 'Services/PageService.ashx/AddSessionEvents'
 
   $SessionEventType = 21
-  $Body = ConvertTo-Json @(
 
   $GuidList = @()
   foreach ($SessionID in $GUID)


### PR DESCRIPTION
Correct Format of Json object when submitting multiple GUID's

The Call allows Multiple GUIDs to be sent in a single call ```[guid[]]$GUID```
Currently when Multiple are passed the Created Json looks like
```
[
  [
    "All Machines"
  ],
  [
    {
      "EventType": 21,
      "SessionID": "719a6448-8713-447e-ad8d-47cbb504a2d5 3ad19bde-40da-4026-a5f7-82aa3bddad8b"
    }
  ]
]
```
which puts multiple GUIDs under a single session ID


This change creates JSON like 
```[["All Machines"],[{"EventType":21,"SessionID":"719a6448-8713-447e-ad8d-47cbb504a2d5"},{"EventType":21,"SessionID":"3ad19bde-40da-4026-a5f7-82aa3bddad8b"}]]```
which matches the calls from the web client 


Expanded for readability
```
[
  [
    "All Machines"
  ],
  [
    {
      "EventType":21,
      "SessionID":"719a6448-8713-447e-ad8d-47cbb504a2d5"
    },
    {
      "EventType":21,
      "SessionID":"3ad19bde-40da-4026-a5f7-82aa3bddad8b"
    }
  ]
]
```




